### PR TITLE
Added check for OBSERVE enablement

### DIFF
--- a/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreConnection.java
@@ -118,6 +118,24 @@ public class SingleStoreConnection {
     }
   }
 
+  public void checkObserveEnabled() throws Exception {
+    try (Statement stmt = getConnection().createStatement();) {
+      ResultSet rs = stmt.executeQuery("SELECT @@enable_observe_queries");
+      try {
+        if (!rs.next()) {
+          throw new Exception("Unable to read @@enable_observe_queries from server response");
+        }
+
+        if (!rs.getBoolean(1)) {
+          throw new Exception(
+              "OBSERVE queries are disabled; Run 'SET GLOBAL enable_observe_queries=1' to enable them");
+        }
+      } finally {
+        rs.close();
+      }
+    }
+  }
+
   public static String escapeTable(String database, String table) {
     return escapeIdentifier(database) + "." + escapeIdentifier(table);
   }

--- a/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreSourceConnectorServiceImpl.java
+++ b/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreSourceConnectorServiceImpl.java
@@ -130,7 +130,11 @@ public class SingleStoreSourceConnectorServiceImpl extends
         .addAllTests(Arrays.asList(
             ConfigurationTest.newBuilder().setName("connect").setLabel("Tests connection").build(),
             ConfigurationTest.newBuilder().setName("table").setLabel("Tests table existence")
-                .build()))
+                .build(),
+            ConfigurationTest.newBuilder().setName("observe")
+                .setLabel("Tests enablement of OBSERVE queries")
+                .build()
+        ))
         .build());
 
     responseObserver.onCompleted();
@@ -148,6 +152,8 @@ public class SingleStoreSourceConnectorServiceImpl extends
         conn.checkConnection();
       } else if (testName.equals("table")) {
         conn.checkTableExistence();
+      } else if (testName.equals("observe")) {
+        conn.checkObserveEnabled();
       }
     } catch (Exception e) {
       logger.warn("Test failed", e);

--- a/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
+++ b/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
@@ -76,7 +76,7 @@ public class SingleStoreConnectionTest extends IntegrationTestBase {
     try (Statement stmt = conn.getConnection().createStatement()) {
       stmt.execute("SET GLOBAL enable_observe_queries=0");
       Assertions.assertThrows(Exception.class, conn::checkObserveEnabled);
-      stmt.execute("SET GLOBAL enable_observe_queries=0");
+      stmt.execute("SET GLOBAL enable_observe_queries=1");
     }
 
   }

--- a/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
+++ b/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
@@ -59,6 +59,29 @@ public class SingleStoreConnectionTest extends IntegrationTestBase {
   }
 
   @Test
+  public void checkObserveEnabledTrue() throws Exception {
+    SingleStoreConfiguration conf = getConfig("checkObserveEnabledTrue");
+    SingleStoreConnection conn = new SingleStoreConnection(conf);
+    try (Statement stmt = conn.getConnection().createStatement()) {
+      stmt.execute("SET GLOBAL enable_observe_queries=1");
+    }
+
+    conn.checkObserveEnabled();
+  }
+
+  @Test
+  public void checkObserveEnabledFalse() throws Exception {
+    SingleStoreConfiguration conf = getConfig("checkObserveEnabledFalse");
+    SingleStoreConnection conn = new SingleStoreConnection(conf);
+    try (Statement stmt = conn.getConnection().createStatement()) {
+      stmt.execute("SET GLOBAL enable_observe_queries=0");
+      Assertions.assertThrows(Exception.class, conn::checkObserveEnabled);
+      stmt.execute("SET GLOBAL enable_observe_queries=0");
+    }
+
+  }
+
+  @Test
   public void checkTableExistenceTrue() throws Exception {
     SingleStoreConfiguration conf = getConfig("checkTableExistenceTrue");
     SingleStoreConnection conn = new SingleStoreConnection(conf);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive validation logic only affects configuration testing and should not impact sync behavior beyond providing earlier failure with clearer messaging when OBSERVE is disabled.
> 
> **Overview**
> Adds a new connector configuration test to verify that SingleStore has `@@enable_observe_queries` enabled before syncing.
> 
> This introduces `SingleStoreConnection.checkObserveEnabled()` (queries `@@enable_observe_queries` and fails with an actionable message when disabled), wires it into `SingleStoreSourceConnectorServiceImpl` as a new `observe` test option, and adds integration tests covering both enabled/disabled server settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51fcc77fd29598e0b8c21e41e5ac7f8de9d87bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->