### PR TITLE
Improved error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 3. Run the Jar.
 
    ```
-   java -jar build/libs/singlestore-fivetran-source-connector-0.0.5.jar
+   java -jar build/libs/singlestore-fivetran-source-connector-0.0.6.jar
    ```
 
 ## Steps for Running Java Tests
@@ -108,7 +108,7 @@
    wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
    wget -O src/main/proto/connector_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/connector_sdk.proto
    gradle jar
-   java -jar build/libs/singlestore-fivetran-source-connector-0.0.5.jar
+   java -jar build/libs/singlestore-fivetran-source-connector-0.0.6.jar
    ```
 
 6. Update the `./tester/configuration.json` file with your credentials.

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     mavenCentral()
 }
 
-version = '0.0.5'
+version = '0.0.6'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreConnection.java
+++ b/src/main/java/com/singlestore/fivetran/source/connector/SingleStoreConnection.java
@@ -128,7 +128,10 @@ public class SingleStoreConnection {
 
         if (!rs.getBoolean(1)) {
           throw new Exception(
-              "OBSERVE queries are disabled; Run 'SET GLOBAL enable_observe_queries=1' to enable them");
+              String.format(
+                  "OBSERVE queries are disabled; Run 'SET GLOBAL enable_observe_queries=1; SNAPSHOT DATABASE %s' to enable them",
+                  escapeIdentifier(stmt.getConnection().getCatalog())
+              ));
         }
       } finally {
         rs.close();

--- a/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
+++ b/src/test/java/com/singlestore/fivetran/source/connector/SingleStoreConnectionTest.java
@@ -75,7 +75,11 @@ public class SingleStoreConnectionTest extends IntegrationTestBase {
     SingleStoreConnection conn = new SingleStoreConnection(conf);
     try (Statement stmt = conn.getConnection().createStatement()) {
       stmt.execute("SET GLOBAL enable_observe_queries=0");
-      Assertions.assertThrows(Exception.class, conn::checkObserveEnabled);
+      Exception ex = Assertions.assertThrows(Exception.class, conn::checkObserveEnabled);
+      assertTrue(ex.getMessage().contains(
+          String.format(
+              "OBSERVE queries are disabled; Run 'SET GLOBAL enable_observe_queries=1; SNAPSHOT DATABASE `%s`' to enable them",
+              database)));
       stmt.execute("SET GLOBAL enable_observe_queries=1");
     }
 


### PR DESCRIPTION
After enabling observe queries, it is important to perform a snapshot. Otherwise, the customer will get wrong offset errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a version bump and a more informative exception message, with tests updated to match; no query/offset logic is altered.
> 
> **Overview**
> Updates the connector version from `0.0.5` to `0.0.6` (Gradle and README run instructions).
> 
> Improves `SingleStoreConnection.checkObserveEnabled()` to instruct users to run `SNAPSHOT DATABASE <db>` after enabling `@@enable_observe_queries`, and updates `SingleStoreConnectionTest` to assert the new error message includes the escaped database name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0864ea71096f72f27f027e1b7e86c27ecc8a928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->