### PR TITLE
chore: Improve release process and version handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-name: Test
+name: CI
 
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
+  push:
+    tags: ["v*"]
   schedule:
     - cron: "0 0 * * 0"
 
@@ -19,7 +21,7 @@ jobs:
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@main
 
-  build:
+  test:
     needs: fetch-s2-versions
     runs-on: ubuntu-latest
 
@@ -57,3 +59,34 @@ jobs:
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:
           arguments: build
+
+  release:
+    permissions:
+      contents: write
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Copy common.proto file
+        run: wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
+      - name: Copy destination_sdk.proto file
+        run: wget -O src/main/proto/connector_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/connector_sdk.proto
+      - name: Set version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Create JAR with Gradle
+        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        with:
+          arguments: jar -Pversion=${{ env.VERSION }}
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          generate_release_notes: true
+          files: build/libs/singlestore-fivetran-source-connector-*.jar
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@
    wget -O src/main/proto/connector_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/connector_sdk.proto
    ```
 
-2. Build the Jar.
+2. Build the Jar (replace version with yours).
 
    ```
-   gradle jar
+   ./gradlew jar -Pversion=<version>
    ```
 
-3. Run the Jar.
+3. Run the Jar (replace version with yours).
 
    ```
-   java -jar build/libs/singlestore-fivetran-source-connector-0.0.6.jar
+   java -jar build/libs/singlestore-fivetran-source-connector-<version>.jar
    ```
 
 ## Steps for Running Java Tests
@@ -63,10 +63,10 @@
    wget -O src/main/proto/connector_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/connector_sdk.proto
    ```
 
-6. Run tests.
+6. Run tests (replace version with yours).
 
    ```
-   gradle build
+   ./gradlew build -Pversion=<version>
    ```
 
 ## Steps for Using Source Connector Tester
@@ -102,13 +102,13 @@
    CREATE TABLE t(a INT PRIMARY KEY, b INT);
    ```
 
-5. Start the Source Connector server.
+5. Start the Source Connector server. (replace version with yours)
 
    ```
    wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
    wget -O src/main/proto/connector_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/connector_sdk.proto
-   gradle jar
-   java -jar build/libs/singlestore-fivetran-source-connector-0.0.6.jar
+   ./gradlew jar -Pversion=<version>
+   java -jar build/libs/singlestore-fivetran-source-connector-<version>.jar
    ```
 
 6. Update the `./tester/configuration.json` file with your credentials.
@@ -134,3 +134,34 @@
 9. Check the content of `./tester/warehouse.db` file.
    using [DuckDB](https://duckdb.org/docs/api/cli/overview.html) CLI
    or [DBeaver](https://duckdb.org/docs/guides/sql_editors/dbeaver)
+
+## Release process
+
+To release a new version:
+
+1. Push a version tag using semantic versioning with a `v` prefix (`v<major>.<minor>.<patch>`, for example `v1.2.3`):
+
+   ```bash
+   git tag v1.0.1
+   git push origin v1.0.1
+   ```
+
+   The package version is derived from the tag (the leading `v` is stripped). This triggers the [CI workflow](.github/workflows/ci.yml), which:
+
+   - Runs the test matrix
+   - Builds the connector JAR with the release version
+   - Creates a [GitHub Release](https://github.com/singlestore-labs/singlestore-fivetran-source-connector/releases) with auto-generated release notes and the JAR (`singlestore-fivetran-source-connector-<version>.jar`)
+
+2. After the GitHub Release is published, post a message in the `#ext-fivetran-singlestore` Slack channel asking Fivetran to upload the updated connector. Replace `<version>` with the release version (for example, `1.2.9` for tag `v1.2.9`):
+
+   ```
+   Hi,
+
+   We have released SingleStore Fivetran Source Connector <version>.
+   GitHub Release: https://github.com/singlestore-labs/singlestore-fivetran-source-connector/releases/tag/v<version>
+
+   Could you please upload the updated version?
+
+   Thanks,
+   <Your name>
+   ```

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     mavenCentral()
 }
 
-version = '0.0.6'
+version = providers.gradleProperty('version').orElse('0.0.0-SNAPSHOT').get()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
 - removed hard-coded version
 - added release workflow
 - added release guide to the README
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, versioning, and documentation; connector runtime behavior is unchanged.
> 
> **Overview**
> **Releases are now tag-driven.** Pushing a `v*` tag runs CI tests, builds a versioned JAR, and publishes a GitHub Release with generated notes and the artifact.
> 
> The connector **no longer hard-codes `0.0.6` in Gradle**—version comes from `-Pversion` or defaults to `0.0.0-SNAPSHOT`. The workflow strips the `v` prefix from the tag for the build. The CI job formerly named `build` is renamed **`test`**; a gated **`release`** job runs only on tag pushes after tests pass.
> 
> **README** updates swap `gradle` for `./gradlew jar -Pversion=<version>` everywhere and document the full release flow (tag → CI → GitHub Release → Slack request to Fivetran).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0388583e1cf8bddb54b90ab0d9f9bccbc3afab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->